### PR TITLE
Allowing a Fraction to be created from a float

### DIFF
--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -9,6 +9,7 @@
 
 namespace Phospr;
 
+use InvalidArgumentException;
 use Phospr\Exception\Fraction\InvalidDenominatorException;
 use Phospr\Exception\Fraction\InvalidNumeratorException;
 
@@ -295,6 +296,42 @@ class Fraction
     public function isInteger()
     {
         return (1 === $this->getDenominator());
+    }
+
+    /*
+     * Create from float
+     *
+     * @author Christopher Tatro <c.m.tatro@gmail.com>
+     * @since  0.2.0
+     *
+     * @param float $float
+     *
+     * return Fraction
+     */
+    public static function fromFloat($float)
+    {
+        // Make sure the float is a float not scientific notation.
+        // Limit a max of 8 chars to prevent float errors
+        $float = rtrim(sprintf('%.8F', $float), 0);
+
+        if (!is_numeric($float)) {
+            throw new InvalidArgumentException("Argument passed is not a numeric value.");
+        }
+
+        // Find and grab the decimal space and everything after it
+        if (false !== ($denominator = strstr($float, '.'))) {
+            // Pad a one with zeros for the length of the decimal places
+            // ie  0.1 = 10; 0.02 = 100; 0.01234 = 100000;
+            $denominator = (int) str_pad('1', strlen($denominator), 0);
+            // Multiply to get rid of the decimal places.
+            $numerator = (int) ($float*$denominator);
+        } else {
+            // No decimal places, this is a whole number
+            $numerator = (int) $float;
+            $denominator = 1;
+        }
+
+        return new self($numerator, $denominator);
     }
 
     /**

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -250,6 +250,22 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test fromFloat()
+     *
+     * @author Christopher Tatro <c.m.tatro@gmail.com>
+     * @since  0.2.0
+     *
+     * @dataProvider fromFloatProvider
+     */
+    public function testFromFloat($float, $numerator, $denominator)
+    {
+        $fraction = Fraction::fromFloat($float);
+
+        $this->assertSame($numerator, $fraction->getNumerator());
+        $this->assertSame($denominator, $fraction->getDenominator());
+    }
+
+    /**
      * Test toFloat()
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
@@ -457,6 +473,48 @@ class FractionTest extends \PHPUnit_Framework_TestCase
             array(14, 7, true),
             array(-14, 7, true),
         );
+    }
+
+
+    /**
+     * From float provider
+     *
+     * @author Christopher Tatro <ctatro@janeiredale.com>
+     * @since  0.2.0
+     *
+     * @return array
+     */
+    public static function fromFloatProvider()
+    {
+        return [
+              [12345.1234, 61725617, 5000],
+              [9999.9999, 99999999, 10000],
+              [0.000001, 1, 1000000],
+              [0.0215011, 215011, 10000000],
+              [0.0000025000, 1, 400000],
+              [0.00001, 1, 100000],
+              [1.25, 5, 4],
+              [1.3245, 2649, 2000],
+              [0.23, 23, 100],
+              [1, 1, 1],
+              [5.5000, 11, 2],
+              [6.375, 51, 8],
+              [235.63247, 23563247, 100000],
+              // Test some negatives
+              [-0.0215011, -215011, 10000000],
+              [-0.0000025000, -1, 400000],
+              [-0.00001, -1, 100000],
+              [-1.25, -5, 4],
+              [-1.3245, -2649, 2000],
+              // Test some strings
+              ['1', 1, 1],
+              ['5', 5, 1],
+              ['5.5000', 11, 2],
+              ['6.375', 51, 8],
+              ['-6.375', -51, 8],
+              ['-1.25', -5, 4],
+              ['-0.00001', -1, 100000],
+          ];
     }
 
     /**


### PR DESCRIPTION
Since we have a toFloat we should have a constructor that is from a float. This functionality is based on the concept that a float is just a fraction in numeric form. https://en.wikipedia.org/wiki/Fraction_%28mathematics%29#Converting_between_decimals_and_fractions