### PR TITLE
Fixing Fraction::fromFloat() (fixes #6)

### DIFF
--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -310,15 +310,15 @@ class Fraction
      */
     public static function fromFloat($float)
     {
-        // Make sure the float is a float not scientific notation.
-        // Limit a max of 8 chars to prevent float errors
-        $float = rtrim(sprintf('%.8F', $float), 0);
-
         if (!is_numeric($float)) {
             throw new InvalidArgumentException(
                 'Argument passed is not a numeric value.'
             );
         }
+
+        // Make sure the float is a float not scientific notation.
+        // Limit a max of 8 chars to prevent float errors
+        $float = rtrim(sprintf('%.8F', $float), 0);
 
         // Find and grab the decimal space and everything after it
         if (false !== ($denominator = strstr($float, '.'))) {

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -266,6 +266,20 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test fromFloat() exceptions
+     *
+     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
+     * @since  0.5.0
+     *
+     * @dataProvider fromFloatExceptionProvider
+     * @expectedException InvalidArgumentException
+     */
+    public function testFromFloatException($float)
+    {
+        $fraction = Fraction::fromFloat($float);
+    }
+
+    /**
      * Test toFloat()
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
@@ -544,6 +558,27 @@ class FractionTest extends \PHPUnit_Framework_TestCase
             ['-1.25', -5, 4],
             ['-0.00001', -1, 100000],
         ];
+    }
+
+    /**
+     * fromFloat exception provider
+     *
+     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
+     * @since  0.5.0
+     *
+     * @return array
+     */
+    public static function fromFloatExceptionProvider()
+    {
+        return [
+              ['foo'],
+              ['1.2.3'],
+              ['1T'],
+              ['- 5'],
+              ['1/2'],
+              ['seven'],
+              ['r009'],
+          ];
     }
 
     /**


### PR DESCRIPTION
Moved rtrim(sprintf('%.8F', $float), 0) below is_numeric check because it was
allowing non-numeric strings to create a Fraction(0)