### PR TITLE
Add `composer test` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
         }
     },
     "scripts": {
-        "test": "phpunit tests/FractionTest.php"
+        "test": "phpunit tests"
      }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
         "psr-4": {
             "Phospr\\": "src"
         }
-    }
+    },
+    "scripts": {
+        "test": "phpunit tests/FractionTest.php"
+     }
 }


### PR DESCRIPTION
`composer test` seems like a common convention for running tests in PHP projects.

This change adds `test` as a script in the composer.json. When you run `composer test` the single test file is run.