### PR TITLE
Add option to skip simplification

### DIFF
--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -53,7 +53,7 @@ class Fraction
      * @param integer $numerator
      * @param integer $denominator
      */
-    public function __construct($numerator, $denominator = 1)
+    public function __construct($numerator, $denominator = 1, $shouldSimplify = true)
     {
         if (!is_int($numerator)) {
             throw new InvalidNumeratorException(
@@ -83,7 +83,9 @@ class Fraction
         $this->numerator = (int) $numerator;
         $this->denominator = (int) $denominator;
 
-        $this->simplify();
+        if ($shouldSimplify) {
+            $this->simplify();
+        }
     }
 
     /**

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -34,6 +34,15 @@ class FractionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(2, $half->getDenominator());
     }
 
+    public function testDontSimplify()
+    {
+        $half = new Fraction(2, 4, false);
+
+        $this->assertEquals('2/4', (string) $half);
+        $this->assertSame(2, $half->getNumerator());
+        $this->assertSame(4, $half->getDenominator());
+    }
+
     /**
      * Test __toString()
      *


### PR DESCRIPTION
Summary
-------
This diff adds a parameter to the constructor of the `Fraction` class
called `$shouldSimplify`. When set to false it skips the last step of
calling the `simplify()` function.

The parameter is defaulted to `true` so there is no change in existing
behavior.

Test Plan
--------
See new unit test.

Questions
---------
- My other thought was making `simplify()` protected so that we could
  subclass it and remove the simplification functionality in a subclass.

Context
-------
We want to be able to validate that a string is "fraction-like", but
keep the format that the string was originally in.