### PR TITLE
Strictly type Fraction class

### DIFF
--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * This file is part of the Phospr Fraction package.
@@ -53,35 +54,23 @@ class Fraction
      * @param integer $numerator
      * @param integer $denominator
      */
-    public function __construct($numerator, $denominator = 1)
+    public function __construct(int $numerator, int $denominator = 1)
     {
-        if (!is_int($numerator)) {
-            throw new InvalidNumeratorException(
-                'Numerator must be an integer'
-            );
-        }
-
-        if (!is_int($denominator)) {
-            throw new InvalidDenominatorException(
-                'Denominator must be an integer'
-            );
-        }
-
-        if ((int) $denominator < 1) {
+        if ($denominator < 1) {
             throw new InvalidDenominatorException(
                 'Denominator must be an integer greater than zero'
             );
         }
 
         if (0 == $numerator) {
-            $this->numerator = (int) 0;
-            $this->denominator = (int) 1;
+            $this->numerator = 0;
+            $this->denominator = 1;
 
             return;
         }
 
-        $this->numerator = (int) $numerator;
-        $this->denominator = (int) $denominator;
+        $this->numerator = $numerator;
+        $this->denominator = $denominator;
 
         $this->simplify();
     }
@@ -94,7 +83,7 @@ class Fraction
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->numerator === $this->denominator) {
             return '1';
@@ -136,7 +125,7 @@ class Fraction
      *
      * @return integer
      */
-    public function getNumerator()
+    public function getNumerator(): int
     {
         return $this->numerator;
     }
@@ -149,7 +138,7 @@ class Fraction
      *
      * @return integer
      */
-    public function getDenominator()
+    public function getDenominator(): int
     {
         return $this->denominator;
     }
@@ -162,7 +151,7 @@ class Fraction
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
      * @since  0.1.0
      *
-     * @return integer
+     * @return void
      */
     private function simplify()
     {
@@ -180,7 +169,7 @@ class Fraction
      *
      * @return integer
      */
-    private function getGreatestCommonDivisor()
+    private function getGreatestCommonDivisor(): int
     {
         $a = $this->numerator;
         $b = $this->denominator;
@@ -217,7 +206,7 @@ class Fraction
      *
      * @return Fraction
      */
-    public function multiply(Fraction $fraction)
+    public function multiply(Fraction $fraction): Fraction
     {
         $numerator = $this->getNumerator() * $fraction->getNumerator();
         $denominator = $this->getDenominator() * $fraction->getDenominator();
@@ -235,7 +224,7 @@ class Fraction
      *
      * @return Fraction
      */
-    public function divide(Fraction $fraction)
+    public function divide(Fraction $fraction): Fraction
     {
         $numerator = $this->getNumerator() * $fraction->getDenominator();
         $denominator = $this->getDenominator() * $fraction->getNumerator();
@@ -253,7 +242,7 @@ class Fraction
      *
      * @return Fraction
      */
-    public function add(Fraction $fraction)
+    public function add(Fraction $fraction): Fraction
     {
         $numerator = ($this->getNumerator() * $fraction->getDenominator())
             + ($fraction->getNumerator() * $this->getDenominator());
@@ -274,7 +263,7 @@ class Fraction
      *
      * @return Fraction
      */
-    public function subtract(Fraction $fraction)
+    public function subtract(Fraction $fraction): Fraction
     {
         $numerator = ($this->getNumerator() * $fraction->getDenominator())
             - ($fraction->getNumerator() * $this->getDenominator());
@@ -293,7 +282,7 @@ class Fraction
      *
      * @return boolean
      */
-    public function isInteger()
+    public function isInteger(): bool
     {
         return (1 === $this->getDenominator());
     }
@@ -306,9 +295,9 @@ class Fraction
      *
      * @param float $float
      *
-     * return Fraction
+     * @return Fraction
      */
-    public static function fromFloat($float)
+    public static function fromFloat(float $float): Fraction
     {
         if (is_int($float)) {
             return new self($float);
@@ -352,7 +341,7 @@ class Fraction
      *
      * return Fraction
      */
-    public static function fromString($string)
+    public static function fromString(string $string): Fraction
     {
         if (preg_match(self::PATTERN_FROM_STRING, trim($string), $matches)) {
             if (2 === count($matches)) {
@@ -389,7 +378,7 @@ class Fraction
      *
      * @return float
      */
-    public function toFloat()
+    public function toFloat(): float
     {
         return $this->getNumerator()/$this->getDenominator();
     }
@@ -406,7 +395,7 @@ class Fraction
      *
      * @return bool
      */
-    public function isSameValueAs(Fraction $fraction)
+    public function isSameValueAs(Fraction $fraction): bool
     {
         if ($this->getNumerator() != $fraction->getNumerator()) {
             return false;

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -215,20 +215,6 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test fromFloat() exceptions
-     *
-     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
-     * @since  0.5.0
-     *
-     * @dataProvider fromFloatExceptionProvider
-     * @expectedException InvalidArgumentException
-     */
-    public function testFromFloatException($float)
-    {
-        $fraction = Fraction::fromFloat($float);
-    }
-
-    /**
      * Test toFloat()
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
@@ -251,20 +237,6 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test bad denominator
-     *
-     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
-     * @since  0.1.0
-     *
-     * @expectedException Phospr\Exception\Fraction\InvalidDenominatorException
-     * @dataProvider badIntegerProvider
-     */
-    public function testBadDenominator($denominator)
-    {
-        $fraction = new Fraction(1, $denominator);
-    }
-
-    /**
      * Test negative denominator
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
@@ -275,20 +247,6 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     public function testNegativeDenominator()
     {
         $fraction = new Fraction(1, -1);
-    }
-
-    /**
-     * Test bad numerator
-     *
-     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
-     * @since  0.1.0
-     *
-     * @expectedException Phospr\Exception\Fraction\InvalidNumeratorException
-     * @dataProvider badIntegerProvider
-     */
-    public function testBadNumerator($numerator)
-    {
-        $fraction = new Fraction($numerator, 1);
     }
 
     /**
@@ -365,29 +323,6 @@ class FractionTest extends \PHPUnit_Framework_TestCase
             array(1, 4, '1/4'),
             array(7, 7, '1'),
             array(7, 21, '1/3'),
-        );
-    }
-
-    /**
-     * Bad integer provider
-     *
-     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
-     * @since  0.1.0
-     *
-     * @return array
-     */
-    public static function badIntegerProvider()
-    {
-        return array(
-            array(null),
-            array(0.4),
-            array(.5),
-            array(''),
-            array(' '),
-            array(1.0),
-            array('5'),
-            array('5i'),
-            array('hello'),
         );
     }
 
@@ -530,27 +465,6 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * fromFloat exception provider
-     *
-     * @author Tom Haskins-Vaughan <tom@tomhv.uk>
-     * @since  0.5.0
-     *
-     * @return array
-     */
-    public static function fromFloatExceptionProvider()
-    {
-        return [
-              ['foo'],
-              ['1.2.3'],
-              ['1T'],
-              ['- 5'],
-              ['1/2'],
-              ['seven'],
-              ['r009'],
-          ];
-    }
-
-    /**
      * To float provider
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>
@@ -561,7 +475,7 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     public static function toFloatProvider()
     {
         return array(
-            array(1, 1, 1),
+            array(1, 1, 1.0),
             array(1, 4, 0.25),
             array(1, 8, 0.125),
         );


### PR DESCRIPTION
In the process of doing this I discovered one bug where `toFloat` would
not always return a float if the numerator and denominator, when
divided, came out to a whole number. Now it will return the float
version of that whole number.

I also deleted a couple test cases that I think are irrelevant in a
scalar type hint world.

**Note**: this would make this library compatible with PHP 7 only. If
that's not acceptable for the new version I'm fine leaving this change
out.