### PR TITLE
Fix to PHP_INT_MAX integer wrap

### DIFF
--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -55,6 +55,10 @@ class Fraction
      */
     public function __construct($numerator, $denominator = 1)
     {
+        list($numerator, $denominator) = $this->checkLimits(
+            $numerator, $denominator
+        );
+
         if (!is_int($numerator)) {
             throw new InvalidNumeratorException(
                 'Numerator must be an integer'
@@ -84,6 +88,45 @@ class Fraction
         $this->denominator = (int) $denominator;
 
         $this->simplify();
+    }
+
+    /**
+     * Check limits
+     *
+     * @param mixed $numerator
+     * @param mixed $denominator
+     * @return array
+     */
+    protected function checkLimits($numerator, $denominator)
+    {
+        if (($max = max($numerator, $denominator)) < PHP_INT_MAX) {
+            return [$numerator, $denominator];
+        }
+
+        $divisor = $this->getDivisor($max);
+
+        return [
+            intval($numerator / $divisor),
+            intval($denominator / $divisor),
+        ];
+    }
+
+    /**
+     * Get divisor
+     *
+     * @param mixed $number
+     * @return integer
+     */
+    protected function getDivisor($number)
+    {
+        $divisor = 1;
+
+        while ($number > PHP_INT_MAX) {
+            $divisor *= 10;
+            $number /= 10;
+        }
+
+        return $divisor;
     }
 
     /**

--- a/src/Fraction.php
+++ b/src/Fraction.php
@@ -99,11 +99,15 @@ class Fraction
      */
     protected function checkLimits($numerator, $denominator)
     {
-        if (($max = max($numerator, $denominator)) < PHP_INT_MAX) {
+        if (($max = max(abs($numerator), abs($denominator))) < PHP_INT_MAX) {
             return [$numerator, $denominator];
         }
 
-        $divisor = $this->getDivisor($max);
+        $divisor = min(
+            abs($this->getDivisor($max)),
+            abs($numerator),
+            abs($denominator)
+        );
 
         return [
             intval($numerator / $divisor),
@@ -121,7 +125,7 @@ class Fraction
     {
         $divisor = 1;
 
-        while ($number > PHP_INT_MAX) {
+        while ($number >= PHP_INT_MAX) {
             $divisor *= 10;
             $number /= 10;
         }

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -20,6 +20,67 @@ use Phospr\Fraction;
 class FractionTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * Big Even Fractions provider
+     *
+     * @return array
+     */
+    public static function bigEvenFractionsProvider()
+    {
+        return array(
+            array(PHP_INT_MAX * 2, PHP_INT_MAX * 4, 1, 2),
+            array(PHP_INT_MAX, PHP_INT_MAX * 8, 1, 8),
+            array(-PHP_INT_MAX * 4, PHP_INT_MAX, -4, 1),
+            array(-PHP_INT_MAX * 8, PHP_INT_MAX * 2, -4, 1),
+        );
+    }
+
+    /**
+     * Test Big Even Fractions.
+     *
+     * @dataProvider bigEvenFractionsProvider
+     */
+    public function testBigEvenFractions(
+        $numerator,
+        $denominator,
+        $expectedNumerator,
+        $expectedDenominator
+    ) {
+        $fraction = new Fraction($numerator, $denominator);
+        $this->assertEquals($fraction->getNumerator(), $expectedNumerator);
+        $this->assertEquals($fraction->getDenominator(), $expectedDenominator);
+    }
+
+    /**
+     * Big Odd Fraction provider
+     *
+     * @return array
+     */
+    public static function bigOddFractionsProvider()
+    {
+        return array(
+            array(PHP_INT_MAX * 1, PHP_INT_MAX * 3, '1/3'),
+            array(PHP_INT_MAX * 2, PHP_INT_MAX * 9, '2/9'),
+            array(-PHP_INT_MAX * 5, PHP_INT_MAX * 8, '-5/8'),
+            array(-PHP_INT_MAX * 7, PHP_INT_MAX * 3, '-7/3'),
+        );
+    }
+
+    /**
+     * Test Big Odd Fractions.
+     *
+     * @dataProvider bigOddFractionsProvider
+     */
+    public function testBigOddFractions(
+        $numerator,
+        $denominator,
+        $expectedFraction
+    ) {
+        $fraction = new Fraction($numerator, $denominator);
+        $expected = Fraction::fromString($expectedFraction);
+        $this->assertLessThan(0.000000000001, abs($fraction->subtract($expected)->toFloat()));
+    }
+
+    /**
      * Test half
      *
      * @author Tom Haskins-Vaughan <tom@tomhv.uk>

--- a/tests/FractionTest.php
+++ b/tests/FractionTest.php
@@ -24,40 +24,13 @@ class FractionTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public static function bigEvenFractionsProvider()
+    public static function bigFractionsProvider()
     {
         return array(
-            array(PHP_INT_MAX * 2, PHP_INT_MAX * 4, 1, 2),
-            array(PHP_INT_MAX, PHP_INT_MAX * 8, 1, 8),
-            array(-PHP_INT_MAX * 4, PHP_INT_MAX, -4, 1),
-            array(-PHP_INT_MAX * 8, PHP_INT_MAX * 2, -4, 1),
-        );
-    }
-
-    /**
-     * Test Big Even Fractions.
-     *
-     * @dataProvider bigEvenFractionsProvider
-     */
-    public function testBigEvenFractions(
-        $numerator,
-        $denominator,
-        $expectedNumerator,
-        $expectedDenominator
-    ) {
-        $fraction = new Fraction($numerator, $denominator);
-        $this->assertEquals($fraction->getNumerator(), $expectedNumerator);
-        $this->assertEquals($fraction->getDenominator(), $expectedDenominator);
-    }
-
-    /**
-     * Big Odd Fraction provider
-     *
-     * @return array
-     */
-    public static function bigOddFractionsProvider()
-    {
-        return array(
+            array(PHP_INT_MAX * 2, PHP_INT_MAX * 4, '1/2'),
+            array(PHP_INT_MAX, PHP_INT_MAX * 8, '1/8'),
+            array(-PHP_INT_MAX * 4, PHP_INT_MAX, '-4'),
+            array(-PHP_INT_MAX * 6, PHP_INT_MAX * 12, '-1/2'),
             array(PHP_INT_MAX * 1, PHP_INT_MAX * 3, '1/3'),
             array(PHP_INT_MAX * 2, PHP_INT_MAX * 9, '2/9'),
             array(-PHP_INT_MAX * 5, PHP_INT_MAX * 8, '-5/8'),
@@ -66,11 +39,11 @@ class FractionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test Big Odd Fractions.
+     * Test Big Fractions.
      *
-     * @dataProvider bigOddFractionsProvider
+     * @dataProvider bigFractionsProvider
      */
-    public function testBigOddFractions(
+    public function testBigFractions(
         $numerator,
         $denominator,
         $expectedFraction


### PR DESCRIPTION
Hi there, I really like your code and included it in a personal project.
After some time, I found myself in the following scenario:

`$fraction1 = new Fraction(1220948601607, 36700000);
$fraction2 = new Fraction(1983415189, 36700000);
$fraction1->add($fraction2)
`

And I got the following error:

> InvalidNumeratorException: Numerator must be an integer

I found that the problem is that one of the params exceeds the PHP_INT_MAX number.
I published a fix and wanted to share it with you in case you'd like to include it in your class.